### PR TITLE
ride_statusesにindexを追加

### DIFF
--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -106,8 +106,7 @@ CREATE TABLE ride_statuses
   app_sent_at     DATETIME(6)                                                                NULL COMMENT 'ユーザーへの状態通知日時',
   chair_sent_at   DATETIME(6)                                                                NULL COMMENT '椅子への状態通知日時',
   PRIMARY KEY (id),
-  INDEX (ride_id, created_at DESC),
-  INDEX (ride_id, created_at ASC)
+  INDEX (ride_id, created_at DESC)
 )
   COMMENT = 'ライドステータスの変更履歴テーブル';
 

--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -106,7 +106,7 @@ CREATE TABLE ride_statuses
   app_sent_at     DATETIME(6)                                                                NULL COMMENT 'ユーザーへの状態通知日時',
   chair_sent_at   DATETIME(6)                                                                NULL COMMENT '椅子への状態通知日時',
   PRIMARY KEY (id),
-  INDEX (ride_id, created_at DESC)
+  INDEX idx_ride_id_created_at (ride_id, created_at DESC)
 )
   COMMENT = 'ライドステータスの変更履歴テーブル';
 

--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -105,7 +105,8 @@ CREATE TABLE ride_statuses
   created_at      DATETIME(6)                                                                NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '状態変更日時',
   app_sent_at     DATETIME(6)                                                                NULL COMMENT 'ユーザーへの状態通知日時',
   chair_sent_at   DATETIME(6)                                                                NULL COMMENT '椅子への状態通知日時',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  INDEX (ride_id, created_at DESC)
 )
   COMMENT = 'ライドステータスの変更履歴テーブル';
 

--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -106,7 +106,8 @@ CREATE TABLE ride_statuses
   app_sent_at     DATETIME(6)                                                                NULL COMMENT 'ユーザーへの状態通知日時',
   chair_sent_at   DATETIME(6)                                                                NULL COMMENT '椅子への状態通知日時',
   PRIMARY KEY (id),
-  INDEX (ride_id, created_at DESC)
+  INDEX (ride_id, created_at DESC),
+  INDEX (ride_id, created_at ASC)
 )
   COMMENT = 'ライドステータスの変更履歴テーブル';
 


### PR DESCRIPTION
ref. #4 

```
Count: 7921  Time=0.03s (235s)  Lock=0.00s (0s)  Rows=1.0 (7921), isucon[isucon]@localhost
  SELECT status FROM ride_statuses WHERE ride_id = 'S' ORDER BY created_at DESC LIMIT N

Count: 3154  Time=0.04s (125s)  Lock=0.00s (0s)  Rows=0.0 (63), isucon[isucon]@localhost
  SELECT * FROM ride_statuses WHERE ride_id = 'S' AND chair_sent_at IS NULL ORDER BY created_at ASC LIMIT N

Count: 2033  Time=0.04s (79s)  Lock=0.00s (0s)  Rows=0.0 (61), isucon[isucon]@localhost
  SELECT * FROM ride_statuses WHERE ride_id = 'S' AND app_sent_at IS NULL ORDER BY created_at ASC LIMIT N

Count: 1683  Time=0.04s (64s)  Lock=0.00s (0s)  Rows=2.3 (3844), isucon[isucon]@localhost
  SELECT * FROM ride_statuses WHERE ride_id = 'S' ORDER BY created_at
```
を改善するためにride_statusesにindexを追加した