### PR TITLE
chairsにindexを追加

### DIFF
--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -32,7 +32,8 @@ CREATE TABLE chairs
   access_token VARCHAR(255) NOT NULL COMMENT 'アクセストークン',
   created_at   DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '登録日時',
   updated_at   DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新日時',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  INDEX idx_access_token (access_token)
 )
   COMMENT = '椅子情報テーブル';
 


### PR DESCRIPTION
https://github.com/daleksprinter/isucon14/issues/10

chairsのaccess_tokenにindexを貼った
idx_access_tokenが使われていて、extraがnullになっていることを確認した

before
```mysql
mysql> explain SELECT * FROM chairs WHERE access_token = '3013d5ec84e1b230f913a17d71ef27c8d09d777b1cce7a3c1e2ffd4040848411';
+----+-------------+--------+------------+------+---------------+------+---------+------+------+----------+-------------+
| id | select_type | table  | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra       |
+----+-------------+--------+------------+------+---------------+------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | chairs | NULL       | ALL  | NULL          | NULL | NULL    | NULL |  533 |    10.00 | Using where |
+----+-------------+--------+------------+------+---------------+------+---------+------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)
```

after
```mysql
mysql> explain SELECT * FROM chairs WHERE access_token = '004c7273bd089f8040e57947644107f0777e0b55cb14638b90ebd03a735de705';
+----+-------------+--------+------------+------+------------------+------------------+---------+-------+------+----------+-------+
| id | select_type | table  | partitions | type | possible_keys    | key              | key_len | ref   | rows | filtered | Extra |
+----+-------------+--------+------------+------+------------------+------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | chairs | NULL       | ref  | idx_access_token | idx_access_token | 1022    | const |    1 |   100.00 | NULL  |
+----+-------------+--------+------------+------+------------------+------------------+---------+-------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)
```