### PR TITLE
ridesとcouponsにindexを貼る

### DIFF
--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -94,7 +94,8 @@ CREATE TABLE rides
   created_at            DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '要求日時',
   updated_at            DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '状態更新日時',
   PRIMARY KEY (id),
-  INDEX idx_chair_id_updated_at (chair_id, updated_at DESC)
+  INDEX idx_chair_id_updated_at (chair_id, updated_at DESC),
+  INDEX idx_user_id_created_at (user_id, created_at DESC)
 )
   COMMENT = 'ライド情報テーブル';
 
@@ -136,7 +137,8 @@ CREATE TABLE coupons
   discount   INTEGER      NOT NULL COMMENT '割引額',
   created_at DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '付与日時',
   used_by    VARCHAR(26)  NULL COMMENT 'クーポンが適用されたライドのID',
-  PRIMARY KEY (user_id, code)
+  PRIMARY KEY (user_id, code),
+  INDEX idx_used_by (used_by)
 )
   COMMENT 'クーポンテーブル';
 


### PR DESCRIPTION
ridesとcouponsのクエリが大きく占めている（2と4番目）のでindexを貼る


```
Count: 30993  Time=0.00s (52s)  Lock=0.00s (0s)  Rows=0.0 (0), isucon[isucon]@localhost
  COMMIT

Count: 9412  Time=0.00s (28s)  Lock=0.00s (0s)  Rows=1.0 (9412), isucon[isucon]@localhost
  SELECT * FROM rides WHERE user_id = 'S' ORDER BY created_at DESC LIMIT N

Count: 438922  Time=0.00s (21s)  Lock=0.00s (0s)  Rows=0.4 (197194), isucon[isucon]@localhost
  #

Count: 9530  Time=0.00s (12s)  Lock=0.00s (0s)  Rows=0.7 (7011), isucon[isucon]@localhost
  SELECT * FROM coupons WHERE used_by = 'S'

```
